### PR TITLE
Move service page galleries under titles

### DIFF
--- a/ecological_restoration.html
+++ b/ecological_restoration.html
@@ -53,14 +53,8 @@
   </div>
 
   <section class="service-detail">
-   <style> padding: 140px 20px 60px; /* Increased top padding to avoid cropping */ </style> 
+   <style> padding: 140px 20px 60px; /* Increased top padding to avoid cropping */ </style>
     <h2>Ecological Restoration</h2>
-    <p>Ecological restoration revitalizes natural habitats by removing invasive species, restoring native vegetation, and repairing soil and water systems. Our work improves biodiversity and creates resilient ecosystems that support wildlife and local communities.</p>
-    <p>Whether transforming degraded forests into thriving woodlands, restoring prairies, or rehabilitating wetlands, our restoration projects strive for long-term ecological health. We collaborate with conservation agencies and landowners to protect and enhance natural areas.</p>
-  </section>
-
-  <section class="service-detail">
-    <h2>Photo Gallery</h2>
     <div class="carousel-container">
       <button class="carousel-arrow left-arrow">&#10094;</button>
       <div class="carousel">
@@ -77,6 +71,8 @@
       </div>
       <button class="carousel-arrow right-arrow">&#10095;</button>
     </div>
+    <p>Ecological restoration revitalizes natural habitats by removing invasive species, restoring native vegetation, and repairing soil and water systems. Our work improves biodiversity and creates resilient ecosystems that support wildlife and local communities.</p>
+    <p>Whether transforming degraded forests into thriving woodlands, restoring prairies, or rehabilitating wetlands, our restoration projects strive for long-term ecological health. We collaborate with conservation agencies and landowners to protect and enhance natural areas.</p>
   </section>
 
   <section id="contact" class="contact">

--- a/garden_design_lawn_care.html
+++ b/garden_design_lawn_care.html
@@ -55,12 +55,6 @@
   <section class="service-detail">
     <style> padding: 140px 20px 60px; /* Increased top padding to avoid cropping */ </style>
     <h2>Garden Design & Lawn Care</h2>
-    <p>Our garden design and lawn care services help you achieve a lush, healthy, and stunning landscape all year round. We create custom garden layouts tailored to your style and preferences, selecting plants that thrive in local conditions.</p>
-    <p>Our comprehensive lawn care program includes mowing, fertilization, aeration, weed control, and seasonal maintenance to keep your grass vibrant and weed-free. From colorful flower beds to perfectly manicured lawns, we provide the expertise to maintain your landscape’s beauty.</p>
-  </section>
-
-  <section class="service-detail">
-    <h2>Photo Gallery</h2>
     <div class="carousel-container">
       <button class="carousel-arrow left-arrow">&#10094;</button>
       <div class="carousel">
@@ -77,6 +71,8 @@
       </div>
       <button class="carousel-arrow right-arrow">&#10095;</button>
     </div>
+    <p>Our garden design and lawn care services help you achieve a lush, healthy, and stunning landscape all year round. We create custom garden layouts tailored to your style and preferences, selecting plants that thrive in local conditions.</p>
+    <p>Our comprehensive lawn care program includes mowing, fertilization, aeration, weed control, and seasonal maintenance to keep your grass vibrant and weed-free. From colorful flower beds to perfectly manicured lawns, we provide the expertise to maintain your landscape’s beauty.</p>
   </section>
 
   <section id="contact" class="contact">

--- a/green_infrastructure.html
+++ b/green_infrastructure.html
@@ -55,12 +55,6 @@
   <section class="service-detail">
     <style> padding: 140px 20px 60px; /* Increased top padding to avoid cropping */ </style>
     <h2>Green Infrastructure</h2>
-    <p>Our green infrastructure services focus on sustainable stormwater management and environmentally responsible design. We implement rain gardens, permeable pavements, bioswales, green roofs, and other features that reduce runoff and pollution while enhancing the natural environment.</p>
-    <p>By integrating green infrastructure solutions into urban and suburban landscapes, we help communities mitigate flooding, improve water quality, and create attractive outdoor spaces that support biodiversity and human well-being.</p>
-  </section>
-
-  <section class="service-detail">
-    <h2>Photo Gallery</h2>
     <div class="carousel-container">
       <button class="carousel-arrow left-arrow">&#10094;</button>
       <div class="carousel">
@@ -77,6 +71,8 @@
       </div>
       <button class="carousel-arrow right-arrow">&#10095;</button>
     </div>
+    <p>Our green infrastructure services focus on sustainable stormwater management and environmentally responsible design. We implement rain gardens, permeable pavements, bioswales, green roofs, and other features that reduce runoff and pollution while enhancing the natural environment.</p>
+    <p>By integrating green infrastructure solutions into urban and suburban landscapes, we help communities mitigate flooding, improve water quality, and create attractive outdoor spaces that support biodiversity and human well-being.</p>
   </section>
 
   <section id="contact" class="contact">

--- a/hardscaping.html
+++ b/hardscaping.html
@@ -55,12 +55,6 @@
   <section class="service-detail">
     <style> padding: 140px 20px 60px; /* Increased top padding to avoid cropping */ </style>
     <h2>Hardscaping</h2>
-    <p>Hardscaping transforms your outdoor living areas with durable and striking elements like patios, walkways, retaining walls, fire pits, outdoor kitchens, and pergolas. We use high-quality stone, pavers, brick, and concrete to create inviting spaces for family gatherings and entertainment.</p>
-    <p>Our skilled artisans tailor each project to your style and functional needs, ensuring your hardscape blends seamlessly with your landscape design. Let us design and build an outdoor retreat that enhances your property’s value and beauty.</p>
-  </section>
-
-  <section class="service-detail">
-    <h2>Photo Gallery</h2>
     <div class="carousel-container">
       <button class="carousel-arrow left-arrow">&#10094;</button>
       <div class="carousel">
@@ -77,6 +71,8 @@
       </div>
       <button class="carousel-arrow right-arrow">&#10095;</button>
     </div>
+    <p>Hardscaping transforms your outdoor living areas with durable and striking elements like patios, walkways, retaining walls, fire pits, outdoor kitchens, and pergolas. We use high-quality stone, pavers, brick, and concrete to create inviting spaces for family gatherings and entertainment.</p>
+    <p>Our skilled artisans tailor each project to your style and functional needs, ensuring your hardscape blends seamlessly with your landscape design. Let us design and build an outdoor retreat that enhances your property’s value and beauty.</p>
   </section>
 
   <section id="contact" class="contact">

--- a/landscape_construction.html
+++ b/landscape_construction.html
@@ -59,13 +59,6 @@
   <style> padding: 140px 20px 60px; /* Increased top padding to avoid cropping */ </style>
   <section class="service-detail">
     <h2>Landscape Construction</h2>
-    <p>Our landscape construction services bring your outdoor vision to life. From custom patios and walkways to garden walls and retaining walls, we handle every aspect of building durable and beautiful landscapes. We design structures that blend seamlessly with your surroundings and provide both functionality and aesthetic appeal.</p>
-    <p>Our team uses top-quality materials and craftsmanship to ensure long-lasting results. Whether you're seeking a new outdoor living area, a beautifully paved pathway, or a sturdy retaining wall to manage slopes, our construction experts deliver on time and on budget.</p>
-  </section>
-
-  <!-- Gallery -->
-  <section class="service-detail">
-    <h2>Photo Gallery</h2>
     <div class="carousel-container">
       <button class="carousel-arrow left-arrow">&#10094;</button>
       <div class="carousel">
@@ -82,6 +75,8 @@
       </div>
       <button class="carousel-arrow right-arrow">&#10095;</button>
     </div>
+    <p>Our landscape construction services bring your outdoor vision to life. From custom patios and walkways to garden walls and retaining walls, we handle every aspect of building durable and beautiful landscapes. We design structures that blend seamlessly with your surroundings and provide both functionality and aesthetic appeal.</p>
+    <p>Our team uses top-quality materials and craftsmanship to ensure long-lasting results. Whether you're seeking a new outdoor living area, a beautifully paved pathway, or a sturdy retaining wall to manage slopes, our construction experts deliver on time and on budget.</p>
   </section>
 
   <!-- Contact -->

--- a/stream_shoreline_restoration.html
+++ b/stream_shoreline_restoration.html
@@ -55,12 +55,6 @@
   <section class="service-detail">
     <style> padding: 140px 20px 60px; /* Increased top padding to avoid cropping */ </style>
     <h2>Stream & Shoreline Restoration</h2>
-    <p>Our stream and shoreline restoration services focus on rehabilitating waterways and shorelines to promote stability, reduce erosion, and enhance habitat. Using bioengineering techniques such as native plantings, rock structures, coir logs, and live staking, we stabilize banks and restore the natural ecology.</p>
-    <p>We work closely with environmental agencies, communities, and property owners to design restoration plans that improve water quality, protect wildlife, and create sustainable recreational areas. Each project is approached with respect for the existing ecosystem and a commitment to long-term success.</p>
-  </section>
-
-  <section class="service-detail">
-    <h2>Photo Gallery</h2>
     <div class="carousel-container">
       <button class="carousel-arrow left-arrow">&#10094;</button>
       <div class="carousel">
@@ -77,7 +71,10 @@
       </div>
       <button class="carousel-arrow right-arrow">&#10095;</button>
     </div>
+    <p>Our stream and shoreline restoration services focus on rehabilitating waterways and shorelines to promote stability, reduce erosion, and enhance habitat. Using bioengineering techniques such as native plantings, rock structures, coir logs, and live staking, we stabilize banks and restore the natural ecology.</p>
+    <p>We work closely with environmental agencies, communities, and property owners to design restoration plans that improve water quality, protect wildlife, and create sustainable recreational areas. Each project is approached with respect for the existing ecosystem and a commitment to long-term success.</p>
   </section>
+
 
   <section id="contact" class="contact">
     <h2>Contact Us</h2>


### PR DESCRIPTION
## Summary
- Place galleries directly beneath the service titles on all non-index pages
- Remove obsolete "Photo Gallery" headings from service pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893ac9a38308321aa22b5b9b1d89d34