### PR TITLE
Add career page images placeholders and styling

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -57,13 +57,20 @@
 <!-- Careers Section -->
 <section class="service-detail careers-section" style="padding: 140px 20px 60px;">
   <h2>Join Our Team at ANA'S Landscaping</h2>
+  <img src="careers1.jpg" alt="Careers at ANA'S Landscaping" class="careers-image" />
   <p>At ANA'S Landscaping LLC, we don’t just build landscapes — we build careers. If you’re looking for a place where you can grow, be part of a positive and skilled team, and take pride in your daily work, you’ve come to the right place.</p>
+
+  <img src="careers2.jpg" alt="Careers at ANA'S Landscaping" class="careers-image" />
 
   <h3>A Positive and Professional Environment</h3>
   <p>We take pride in the atmosphere we’ve created. Our team works in harmony to deliver beautiful outdoor environments with care, precision, and professionalism. We encourage creativity, teamwork, and a strong work ethic while fostering camaraderie and respect.</p>
 
+  <img src="careers3.jpg" alt="Careers at ANA'S Landscaping" class="careers-image" />
+
   <h3>Year-Round Reliable Work</h3>
   <p>We offer more than seasonal work. Thanks to our wide range of landscaping, construction, and ecological services, we provide full-time, year-round employment opportunities so our staff can rely on a stable income all year long.</p>
+
+  <img src="careers4.jpg" alt="Careers at ANA'S Landscaping" class="careers-image" />
 
   <h3>Top Pay & Great Benefits</h3>
   <ul>
@@ -74,11 +81,17 @@
     <li>Support for continuing education and industry certifications</li>
   </ul>
 
+  <img src="careers5.jpg" alt="Careers at ANA'S Landscaping" class="careers-image" />
+
   <h3>We Support Our Community</h3>
   <p>We’re proud to give back — from donating trees to offering free landscaping support for local spaces. At ANA'S, your work makes a lasting impact on both our clients and our community.</p>
 
+  <img src="careers6.jpg" alt="Careers at ANA'S Landscaping" class="careers-image" />
+
   <h3>We’re Hiring!</h3>
   <p>If you’re passionate, hardworking, and ready to grow in a rewarding environment, apply for one of our open positions:</p>
+
+  <img src="careers7.jpg" alt="Careers at ANA'S Landscaping" class="careers-image" />
   <ul>
     <li>Production Manager</li>
     <li>Account Manager</li>
@@ -91,6 +104,8 @@
     <li>Construction Crew Member</li>
     <li>Maintenance Crew Member</li>
   </ul>
+
+  <img src="careers8.jpg" alt="Careers at ANA'S Landscaping" class="careers-image" />
 
   <p>To apply, please email your resume to <a href="mailto:anaslandscapingllc@gmail.com">anaslandscapingllc@gmail.com</a> or visit our <a href="index.html#contact">Contact Section</a>.</p>
 </section>

--- a/styles.css
+++ b/styles.css
@@ -570,3 +570,12 @@ section { padding-top: 100px; }
   line-height: 1.8;
 }
 
+.careers-image {
+  width: 100%;
+  max-width: 600px;
+  height: auto;
+  display: block;
+  margin: 20px auto;
+  border-radius: 8px;
+}
+


### PR DESCRIPTION
## Summary
- Display sequential career images under the page title and between major content blocks.
- Style career images to be responsive and centered.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893b9c9e5b48321b684d91338b4a0d8