### PR TITLE
Refine hero quote and improve mobile navigation

### DIFF
--- a/script.js
+++ b/script.js
@@ -33,18 +33,35 @@ function initMobileMenu() {
   mobileMenu.addEventListener('click', function (e) {
     e.stopPropagation();
   });
+}
 
-  // Close menu when a menu link is clicked
-  mobileMenu.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', function () {
-      mobileMenu.classList.remove('show');
-      hamburger.classList.remove('active');
+function initSectionObserver() {
+  const sections = document.querySelectorAll('section[id]');
+  const options = { threshold: 0.6 };
+
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      const id = entry.target.getAttribute('id');
+      document.querySelectorAll(`a[href="#${id}"]`).forEach(link => {
+        if (entry.isIntersecting) {
+          link.classList.add('active');
+        } else {
+          link.classList.remove('active');
+        }
+      });
     });
-  });
+  }, options);
+
+  sections.forEach(section => observer.observe(section));
+}
+
+function init() {
+  initMobileMenu();
+  initSectionObserver();
 }
 
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initMobileMenu);
+  document.addEventListener('DOMContentLoaded', init);
 } else {
-  initMobileMenu();
+  init();
 }

--- a/styles.css
+++ b/styles.css
@@ -67,6 +67,11 @@ body.needs-extra-padding {
   transition: color 0.3s ease, text-shadow 0.3s ease;
 }
 .main-nav ul li a:hover { color: white; text-shadow: 0 0 10px white; }
+/* Highlight active navigation link */
+.main-nav ul li a.active,
+.mobile-menu ul li a.active {
+  color: lightgreen;
+}
 
 .hamburger {
   display: none;
@@ -158,7 +163,7 @@ body.needs-extra-padding {
   opacity: 0.8;
 }
 @media (max-width: 768px) {
-  .main-banner { padding-top: 180px; }
+  .main-banner { padding-top: 100px; }
 }
 .main-banner::before {
   content: '';
@@ -172,13 +177,18 @@ body.needs-extra-padding {
 }
 
 .hero-motto {
-  color: #2e7d32;
+  color: white;
   font-weight: bold;
   text-shadow: 0 0 5px rgba(255,255,255,0.7), 2px 2px 4px #000;
   font-family: 'Playfair Display', serif;
   font-style: italic;
   font-size: 2rem;
   margin-bottom: 15px;
+}
+@media (min-width: 1024px) {
+  .hero-motto {
+    font-size: 2.5rem;
+  }
 }
 
 .request-estimate-btn {


### PR DESCRIPTION
## Summary
- Make hero quote white and bold again with larger desktop size and less mobile top padding.
- Keep mobile menu open when navigating and highlight active section links in light green.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68977409ec9883219dc5651b8eb7a178