### PR TITLE
Fix mobile motto layout and navigation highlight

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
   <!-- Main Banner -->
   <section class="main-banner" style="background: url('landscapeconstruction.jpeg') no-repeat center center/cover; background-size: cover;">
     <p class="hero-motto">
-      “Serving Chicagoland’s landscape professionals with excellence for over <span class="motto-years">30 years</span>.”
+      “Serving Chicagoland’s landscape professionals with excellence for over <span class="motto-years">30 years.</span>”
     </p>
     <a href="#contact" class="read-more-btn request-estimate-btn">Request Estimate</a>
   </section>

--- a/script.js
+++ b/script.js
@@ -53,7 +53,7 @@ function initMobileMenu() {
 
 function initSectionObserver() {
   const sections = document.querySelectorAll('section[id]');
-  const options = { threshold: 0.6 };
+  const options = { threshold: 0.3 };
 
   const observer = new IntersectionObserver((entries) => {
     entries.forEach(entry => {
@@ -86,12 +86,17 @@ if (document.readyState === 'loading') {
 
 function highlightCurrentPage() {
   const path = window.location.pathname.split('/').pop();
-  if (path) {
+  if (path && path !== 'index.html') {
     document.querySelectorAll(`a[href='${path}']`).forEach(link => {
+      link.classList.add('active');
+    });
+  } else {
+    document.querySelectorAll("a[href='#about']").forEach(link => {
       link.classList.add('active');
     });
   }
 }
+
 
 function openMenuIfFlag() {
   if (localStorage.getItem('keepMobileMenuOpen') === 'true') {


### PR DESCRIPTION
## Summary
- Keep period aligned with “30 years” in mobile hero motto
- Highlight About Us link by default and lower section observer threshold for better mobile navigation feedback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68977a8b8d0083218f6385269dad69a9