### PR TITLE
Fix hero motto quotes alignment on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
   <!-- Main Banner -->
   <section class="main-banner" style="background: url('landscapeconstruction.jpeg') no-repeat center center/cover; background-size: cover;">
     <p class="hero-motto">
-      “Serving Chicagoland’s landscape professionals with excellence for over <span class="motto-years">30 years.</span>”
+      “Serving Chicagoland’s landscape professionals with excellence for over <span class="motto-years">30 years.”</span>
     </p>
     <a href="#contact" class="read-more-btn request-estimate-btn">Request Estimate</a>
   </section>


### PR DESCRIPTION
## Summary
- Keep closing quotation mark with the `30 years` text to avoid stray quote on mobile

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897804a00cc83219c3597daa16c93b0