### PR TITLE
Fix mobile hero motto quotation wrapping

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -187,6 +187,7 @@ body.needs-extra-padding {
 }
 .hero-motto .motto-years {
   display: inline;
+  white-space: nowrap;
 }
 @media (max-width: 600px) {
   .hero-motto {
@@ -194,6 +195,7 @@ body.needs-extra-padding {
   }
   .hero-motto .motto-years {
     display: block;
+    white-space: nowrap;
   }
 }
 @media (min-width: 1024px) {


### PR DESCRIPTION
## Summary
- Prevent mobile layout from wrapping the closing quotation mark away from "30 years." by enforcing no line breaks within the highlighted motto text.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68978316b7c883218ba73f2a5f727d10