### PR TITLE
Fix hidden nav links on desktop

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -68,7 +68,10 @@ body.needs-extra-padding {
 }
 .main-nav ul li a:hover { color: white; text-shadow: 0 0 10px white; }
 /* Highlight active navigation link */
-.main-nav ul li a.active,
+.main-nav ul li a.active {
+  color: darkgreen;
+}
+
 .mobile-menu ul li a.active {
   color: lightgreen;
 }


### PR DESCRIPTION
## Summary
- Ensure active desktop navigation links use a contrasting dark green color
- Keep mobile menu highlight as light green for visibility on dark overlay

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689785173e5883218935a3de2a518462