### PR TITLE
Fix navigation visibility and add Careers link across site

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -31,6 +31,7 @@
       <li><a href="index.html#projects">Projects</a></li>
       <li><a href="index.html#testimonials">Testimonials</a></li>
       <li><a href="index.html#contact">Contact</a></li>
+      <li><a href="careers.html">Careers</a></li>
     </ul>
     <div class="hamburger"><i class="fas fa-bars"></i></div>
   </nav>

--- a/commercial_maintenance.html
+++ b/commercial_maintenance.html
@@ -30,6 +30,7 @@
         <li><a href="index.html#projects">Projects</a></li>
         <li><a href="index.html#testimonials">Testimonials</a></li>
         <li><a href="index.html#contact">Contact</a></li>
+        <li><a href="careers.html">Careers</a></li>
       </ul>
       <div class="hamburger">
         <i class="fas fa-bars"></i>
@@ -46,6 +47,7 @@
       <li><a href="index.html#projects">Projects</a></li>
       <li><a href="index.html#testimonials">Testimonials</a></li>
       <li><a href="index.html#contact">Contact</a></li>
+      <li><a href="careers.html">Careers</a></li>
     </ul>
   </div>
 

--- a/ecological_restoration.html
+++ b/ecological_restoration.html
@@ -29,6 +29,7 @@
         <li><a href="index.html#projects">Projects</a></li>
         <li><a href="index.html#testimonials">Testimonials</a></li>
         <li><a href="index.html#contact">Contact</a></li>
+        <li><a href="careers.html">Careers</a></li>
       </ul>
       <div class="hamburger">
         <i class="fas fa-bars"></i>
@@ -44,6 +45,7 @@
       <li><a href="index.html#projects">Projects</a></li>
       <li><a href="index.html#testimonials">Testimonials</a></li>
       <li><a href="index.html#contact">Contact</a></li>
+      <li><a href="careers.html">Careers</a></li>
     </ul>
   </div>
 

--- a/garden_design_lawn_care.html
+++ b/garden_design_lawn_care.html
@@ -29,6 +29,7 @@
         <li><a href="index.html#projects">Projects</a></li>
         <li><a href="index.html#testimonials">Testimonials</a></li>
         <li><a href="index.html#contact">Contact</a></li>
+        <li><a href="careers.html">Careers</a></li>
       </ul>
       <div class="hamburger">
         <i class="fas fa-bars"></i>
@@ -44,6 +45,7 @@
       <li><a href="index.html#projects">Projects</a></li>
       <li><a href="index.html#testimonials">Testimonials</a></li>
       <li><a href="index.html#contact">Contact</a></li>
+      <li><a href="careers.html">Careers</a></li>
     </ul>
   </div>
 

--- a/green_infrastructure.html
+++ b/green_infrastructure.html
@@ -29,6 +29,7 @@
         <li><a href="index.html#projects">Projects</a></li>
         <li><a href="index.html#testimonials">Testimonials</a></li>
         <li><a href="index.html#contact">Contact</a></li>
+        <li><a href="careers.html">Careers</a></li>
       </ul>
       <div class="hamburger">
         <i class="fas fa-bars"></i>
@@ -44,6 +45,7 @@
       <li><a href="index.html#projects">Projects</a></li>
       <li><a href="index.html#testimonials">Testimonials</a></li>
       <li><a href="index.html#contact">Contact</a></li>
+      <li><a href="careers.html">Careers</a></li>
     </ul>
   </div>
 

--- a/hardscaping.html
+++ b/hardscaping.html
@@ -29,6 +29,7 @@
         <li><a href="index.html#projects">Projects</a></li>
         <li><a href="index.html#testimonials">Testimonials</a></li>
         <li><a href="index.html#contact">Contact</a></li>
+        <li><a href="careers.html">Careers</a></li>
       </ul>
       <div class="hamburger">
         <i class="fas fa-bars"></i>
@@ -44,6 +45,7 @@
       <li><a href="index.html#projects">Projects</a></li>
       <li><a href="index.html#testimonials">Testimonials</a></li>
       <li><a href="index.html#contact">Contact</a></li>
+      <li><a href="careers.html">Careers</a></li>
     </ul>
   </div>
 

--- a/landscape_construction.html
+++ b/landscape_construction.html
@@ -30,6 +30,7 @@
         <li><a href="index.html#projects">Projects</a></li>
         <li><a href="index.html#testimonials">Testimonials</a></li>
         <li><a href="index.html#contact">Contact</a></li>
+        <li><a href="careers.html">Careers</a></li>
       </ul>
       <div class="hamburger">
         <i class="fas fa-bars"></i>
@@ -46,6 +47,7 @@
       <li><a href="index.html#projects">Projects</a></li>
       <li><a href="index.html#testimonials">Testimonials</a></li>
       <li><a href="index.html#contact">Contact</a></li>
+      <li><a href="careers.html">Careers</a></li>
     </ul>
   </div>
 

--- a/snow.html
+++ b/snow.html
@@ -30,6 +30,7 @@
         <li><a href="index.html#projects">Projects</a></li>
         <li><a href="index.html#testimonials">Testimonials</a></li>
         <li><a href="index.html#contact">Contact</a></li>
+        <li><a href="careers.html">Careers</a></li>
       </ul>
       <div class="hamburger">
         <i class="fas fa-bars"></i>
@@ -46,6 +47,7 @@
       <li><a href="index.html#projects">Projects</a></li>
       <li><a href="index.html#testimonials">Testimonials</a></li>
       <li><a href="index.html#contact">Contact</a></li>
+      <li><a href="careers.html">Careers</a></li>
     </ul>
   </div>
 

--- a/stream_shoreline_restoration.html
+++ b/stream_shoreline_restoration.html
@@ -29,6 +29,7 @@
         <li><a href="index.html#projects">Projects</a></li>
         <li><a href="index.html#testimonials">Testimonials</a></li>
         <li><a href="index.html#contact">Contact</a></li>
+        <li><a href="careers.html">Careers</a></li>
       </ul>
       <div class="hamburger">
         <i class="fas fa-bars"></i>
@@ -44,6 +45,7 @@
       <li><a href="index.html#projects">Projects</a></li>
       <li><a href="index.html#testimonials">Testimonials</a></li>
       <li><a href="index.html#contact">Contact</a></li>
+      <li><a href="careers.html">Careers</a></li>
     </ul>
   </div>
 

--- a/styles.css
+++ b/styles.css
@@ -57,8 +57,9 @@ body.needs-extra-padding {
 
 .main-nav ul {
   display: flex;
-  justify-content: center;
+  justify-content: space-around;
   flex-grow: 1;
+  flex-wrap: wrap;
 }
 .main-nav ul li { margin: 0 15px; }
 .main-nav ul li a {


### PR DESCRIPTION
## Summary
- Distribute navigation items to keep "About Us" and "Solutions" visible on desktop.
- Add "Careers" link to desktop and mobile menus on services and careers pages.

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689786c50d048321bf4c424566cb9f03