### PR TITLE
Rename projects to portfolio and enable infinite sliders

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -28,7 +28,7 @@
     <ul class="desktop-menu">
       <li><a href="index.html#about">About Us</a></li>
       <li><a href="index.html#solutions">Solutions</a></li>
-      <li><a href="index.html#projects">Projects</a></li>
+      <li><a href="index.html#projects">Portfolio</a></li>
       <li><a href="index.html#testimonials">Testimonials</a></li>
       <li><a href="index.html#contact">Contact</a></li>
       <li><a href="careers.html">Careers</a></li>
@@ -43,7 +43,7 @@
   <ul>
     <li><a href="index.html#about">About Us</a></li>
     <li><a href="index.html#solutions">Solutions</a></li>
-    <li><a href="index.html#projects">Projects</a></li>
+    <li><a href="index.html#projects">Portfolio</a></li>
     <li><a href="index.html#testimonials">Testimonials</a></li>
     <li><a href="index.html#contact">Contact</a></li>
     <li><a href="careers.html">Careers</a></li>
@@ -64,7 +64,7 @@
 </div>
 
 <!-- Careers Section -->
-<section class="service-detail careers-section" style="padding: 140px 20px 60px;">
+<section class="service-detail careers-section">
   <h2>Join Our Team!</h2>
   <img src="careers1.jpg" alt="Careers at ANA'S Landscaping" class="careers-image" />
   <p>At ANA'S Landscaping LLC, we don’t just build landscapes — we build careers. If you’re looking for a place where you can grow, be part of a positive and skilled team, and take pride in your daily work, you’ve come to the right place.</p>
@@ -150,43 +150,6 @@
   <p>Developed by <a href="https://saasproductized.com" target="_blank" style="font-weight: bold;">SaaS Productized Co.</a></p>
 </div>
 
-<!-- Carousel Script -->
-<script>
-  document.addEventListener("DOMContentLoaded", function () {
-    const carousel = document.querySelector('.carousel-images');
-    const slides = document.querySelectorAll('.carousel-img');
-    const leftArrow = document.querySelector('.left-arrow');
-    const rightArrow = document.querySelector('.right-arrow');
-
-    let currentIndex = 0;
-    const imagesToShow = 1;
-    let imageWidth = slides[0]?.clientWidth || 0;
-
-    function updateCarousel() {
-      const newTransformValue = -currentIndex * imageWidth;
-      carousel.style.transform = \`translateX(\${newTransformValue}px)\`;
-    }
-
-    rightArrow?.addEventListener('click', () => {
-      if (currentIndex < slides.length - imagesToShow) {
-        currentIndex++;
-        updateCarousel();
-      }
-    });
-
-    leftArrow?.addEventListener('click', () => {
-      if (currentIndex > 0) {
-        currentIndex--;
-        updateCarousel();
-      }
-    });
-
-    window.addEventListener('resize', () => {
-      imageWidth = slides[0]?.clientWidth || 0;
-      updateCarousel();
-    });
-  });
-</script>
 </body>
 </html>
 

--- a/commercial_maintenance.html
+++ b/commercial_maintenance.html
@@ -27,7 +27,7 @@
       <ul class="desktop-menu">
         <li><a href="index.html#about">About Us</a></li>
         <li><a href="index.html#solutions">Solutions</a></li>
-        <li><a href="index.html#projects">Projects</a></li>
+        <li><a href="index.html#projects">Portfolio</a></li>
         <li><a href="index.html#testimonials">Testimonials</a></li>
         <li><a href="index.html#contact">Contact</a></li>
         <li><a href="careers.html">Careers</a></li>
@@ -44,7 +44,7 @@
     <ul>
       <li><a href="index.html#about">About Us</a></li>
       <li><a href="index.html#solutions">Solutions</a></li>
-      <li><a href="index.html#projects">Projects</a></li>
+      <li><a href="index.html#projects">Portfolio</a></li>
       <li><a href="index.html#testimonials">Testimonials</a></li>
       <li><a href="index.html#contact">Contact</a></li>
       <li><a href="careers.html">Careers</a></li>
@@ -121,44 +121,7 @@
     <p>Developed by <a href="https://saasproductized.com" target="_blank" style="font-weight: bold;">SaaS Productized Co.</a></p>
   </div>
 
-  <!-- Script -->
-  <script>
-    document.addEventListener("DOMContentLoaded", function () {
-      const carousel = document.querySelector('.carousel-images');
-      const slides = document.querySelectorAll('.carousel-img');
-      const leftArrow = document.querySelector('.left-arrow');
-      const rightArrow = document.querySelector('.right-arrow');
-
-      let currentIndex = 0;
-      const imagesToShow = 1;
-      let imageWidth = slides[0].clientWidth;
-
-      function updateCarousel() {
-        const newTransformValue = -currentIndex * imageWidth;
-        carousel.style.transform = \`translateX(\${newTransformValue}px)\`;
-      }
-
-      rightArrow.addEventListener('click', () => {
-        if (currentIndex < slides.length - imagesToShow) {
-          currentIndex++;
-          updateCarousel();
-        }
-      });
-
-      leftArrow.addEventListener('click', () => {
-        if (currentIndex > 0) {
-          currentIndex--;
-          updateCarousel();
-        }
-      });
-
-      window.addEventListener('resize', () => {
-        imageWidth = slides[0].clientWidth;
-        updateCarousel();
-      });
-    });
-  </script>
-</body>
+  </body>
 </html>
 
 

--- a/ecological_restoration.html
+++ b/ecological_restoration.html
@@ -26,7 +26,7 @@
       <ul class="desktop-menu">
         <li><a href="index.html#about">About Us</a></li>
         <li><a href="index.html#solutions">Solutions</a></li>
-        <li><a href="index.html#projects">Projects</a></li>
+        <li><a href="index.html#projects">Portfolio</a></li>
         <li><a href="index.html#testimonials">Testimonials</a></li>
         <li><a href="index.html#contact">Contact</a></li>
         <li><a href="careers.html">Careers</a></li>
@@ -42,7 +42,7 @@
     <ul>
       <li><a href="index.html#about">About Us</a></li>
       <li><a href="index.html#solutions">Solutions</a></li>
-      <li><a href="index.html#projects">Projects</a></li>
+      <li><a href="index.html#projects">Portfolio</a></li>
       <li><a href="index.html#testimonials">Testimonials</a></li>
       <li><a href="index.html#contact">Contact</a></li>
       <li><a href="careers.html">Careers</a></li>
@@ -113,42 +113,7 @@
     <p>Developed by <a href="https://saasproductized.com" target="_blank" style="font-weight:bold;">SaaS Productized Co.</a></p>
   </div>
 
-  <script>
-    document.addEventListener("DOMContentLoaded", function () {
-      const carousel = document.querySelector('.carousel-images');
-      const slides = document.querySelectorAll('.carousel-img');
-      const leftArrow = document.querySelector('.left-arrow');
-      const rightArrow = document.querySelector('.right-arrow');
-      let currentIndex = 0;
-      const imagesToShow = 1;
-      let imageWidth = slides[0].clientWidth;
-
-      function updateCarousel() {
-        const newTransformValue = -currentIndex * imageWidth;
-        carousel.style.transform = \`translateX(\${newTransformValue}px)\`;
-      }
-
-      rightArrow.addEventListener('click', () => {
-        if (currentIndex < slides.length - imagesToShow) {
-          currentIndex++;
-          updateCarousel();
-        }
-      });
-
-      leftArrow.addEventListener('click', () => {
-        if (currentIndex > 0) {
-          currentIndex--;
-          updateCarousel();
-        }
-      });
-
-      window.addEventListener('resize', () => {
-        imageWidth = slides[0].clientWidth;
-        updateCarousel();
-      });
-    });
-  </script>
-</body>
+  </body>
 </html>
 
 

--- a/garden_design_lawn_care.html
+++ b/garden_design_lawn_care.html
@@ -26,7 +26,7 @@
       <ul class="desktop-menu">
         <li><a href="index.html#about">About Us</a></li>
         <li><a href="index.html#solutions">Solutions</a></li>
-        <li><a href="index.html#projects">Projects</a></li>
+        <li><a href="index.html#projects">Portfolio</a></li>
         <li><a href="index.html#testimonials">Testimonials</a></li>
         <li><a href="index.html#contact">Contact</a></li>
         <li><a href="careers.html">Careers</a></li>
@@ -42,7 +42,7 @@
     <ul>
       <li><a href="index.html#about">About Us</a></li>
       <li><a href="index.html#solutions">Solutions</a></li>
-      <li><a href="index.html#projects">Projects</a></li>
+      <li><a href="index.html#projects">Portfolio</a></li>
       <li><a href="index.html#testimonials">Testimonials</a></li>
       <li><a href="index.html#contact">Contact</a></li>
       <li><a href="careers.html">Careers</a></li>
@@ -113,42 +113,7 @@
     <p>Developed by <a href="https://saasproductized.com" target="_blank" style="font-weight:bold;">SaaS Productized Co.</a></p>
   </div>
 
-  <script>
-    document.addEventListener("DOMContentLoaded", function () {
-      const carousel = document.querySelector('.carousel-images');
-      const slides = document.querySelectorAll('.carousel-img');
-      const leftArrow = document.querySelector('.left-arrow');
-      const rightArrow = document.querySelector('.right-arrow');
-      let currentIndex = 0;
-      const imagesToShow = 1;
-      let imageWidth = slides[0].clientWidth;
-
-      function updateCarousel() {
-        const newTransformValue = -currentIndex * imageWidth;
-        carousel.style.transform = \`translateX(\${newTransformValue}px)\`;
-      }
-
-      rightArrow.addEventListener('click', () => {
-        if (currentIndex < slides.length - imagesToShow) {
-          currentIndex++;
-          updateCarousel();
-        }
-      });
-
-      leftArrow.addEventListener('click', () => {
-        if (currentIndex > 0) {
-          currentIndex--;
-          updateCarousel();
-        }
-      });
-
-      window.addEventListener('resize', () => {
-        imageWidth = slides[0].clientWidth;
-        updateCarousel();
-      });
-    });
-  </script>
-</body>
+  </body>
 </html>
 
 

--- a/green_infrastructure.html
+++ b/green_infrastructure.html
@@ -26,7 +26,7 @@
       <ul class="desktop-menu">
         <li><a href="index.html#about">About Us</a></li>
         <li><a href="index.html#solutions">Solutions</a></li>
-        <li><a href="index.html#projects">Projects</a></li>
+        <li><a href="index.html#projects">Portfolio</a></li>
         <li><a href="index.html#testimonials">Testimonials</a></li>
         <li><a href="index.html#contact">Contact</a></li>
         <li><a href="careers.html">Careers</a></li>
@@ -42,7 +42,7 @@
     <ul>
       <li><a href="index.html#about">About Us</a></li>
       <li><a href="index.html#solutions">Solutions</a></li>
-      <li><a href="index.html#projects">Projects</a></li>
+      <li><a href="index.html#projects">Portfolio</a></li>
       <li><a href="index.html#testimonials">Testimonials</a></li>
       <li><a href="index.html#contact">Contact</a></li>
       <li><a href="careers.html">Careers</a></li>
@@ -113,42 +113,7 @@
     <p>Developed by <a href="https://saasproductized.com" target="_blank" style="font-weight:bold;">SaaS Productized Co.</a></p>
   </div>
 
-  <script>
-    document.addEventListener("DOMContentLoaded", function () {
-      const carousel = document.querySelector('.carousel-images');
-      const slides = document.querySelectorAll('.carousel-img');
-      const leftArrow = document.querySelector('.left-arrow');
-      const rightArrow = document.querySelector('.right-arrow');
-      let currentIndex = 0;
-      const imagesToShow = 1;
-      let imageWidth = slides[0].clientWidth;
-
-      function updateCarousel() {
-        const newTransformValue = -currentIndex * imageWidth;
-        carousel.style.transform = \`translateX(\${newTransformValue}px)\`;
-      }
-
-      rightArrow.addEventListener('click', () => {
-        if (currentIndex < slides.length - imagesToShow) {
-          currentIndex++;
-          updateCarousel();
-        }
-      });
-
-      leftArrow.addEventListener('click', () => {
-        if (currentIndex > 0) {
-          currentIndex--;
-          updateCarousel();
-        }
-      });
-
-      window.addEventListener('resize', () => {
-        imageWidth = slides[0].clientWidth;
-        updateCarousel();
-      });
-    });
-  </script>
-</body>
+  </body>
 </html>
 
 

--- a/hardscaping.html
+++ b/hardscaping.html
@@ -26,7 +26,7 @@
       <ul class="desktop-menu">
         <li><a href="index.html#about">About Us</a></li>
         <li><a href="index.html#solutions">Solutions</a></li>
-        <li><a href="index.html#projects">Projects</a></li>
+        <li><a href="index.html#projects">Portfolio</a></li>
         <li><a href="index.html#testimonials">Testimonials</a></li>
         <li><a href="index.html#contact">Contact</a></li>
         <li><a href="careers.html">Careers</a></li>
@@ -42,7 +42,7 @@
     <ul>
       <li><a href="index.html#about">About Us</a></li>
       <li><a href="index.html#solutions">Solutions</a></li>
-      <li><a href="index.html#projects">Projects</a></li>
+      <li><a href="index.html#projects">Portfolio</a></li>
       <li><a href="index.html#testimonials">Testimonials</a></li>
       <li><a href="index.html#contact">Contact</a></li>
       <li><a href="careers.html">Careers</a></li>
@@ -113,42 +113,7 @@
     <p>Developed by <a href="https://saasproductized.com" target="_blank" style="font-weight:bold;">SaaS Productized Co.</a></p>
   </div>
 
-  <script>
-    document.addEventListener("DOMContentLoaded", function () {
-      const carousel = document.querySelector('.carousel-images');
-      const slides = document.querySelectorAll('.carousel-img');
-      const leftArrow = document.querySelector('.left-arrow');
-      const rightArrow = document.querySelector('.right-arrow');
-      let currentIndex = 0;
-      const imagesToShow = 1;
-      let imageWidth = slides[0].clientWidth;
-
-      function updateCarousel() {
-        const newTransformValue = -currentIndex * imageWidth;
-        carousel.style.transform = \`translateX(\${newTransformValue}px)\`;
-      }
-
-      rightArrow.addEventListener('click', () => {
-        if (currentIndex < slides.length - imagesToShow) {
-          currentIndex++;
-          updateCarousel();
-        }
-      });
-
-      leftArrow.addEventListener('click', () => {
-        if (currentIndex > 0) {
-          currentIndex--;
-          updateCarousel();
-        }
-      });
-
-      window.addEventListener('resize', () => {
-        imageWidth = slides[0].clientWidth;
-        updateCarousel();
-      });
-    });
-  </script>
-</body>
+  </body>
 </html>
 
 

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
       <ul class="desktop-menu">
         <li><a href="#about">About Us</a></li>
         <li><a href="#solutions">Solutions</a></li>
-        <li><a href="#projects">Projects</a></li>
+        <li><a href="#projects">Portfolio</a></li>
         <li><a href="#testimonials">Testimonials</a></li>
         <li><a href="#contact">Contact</a></li>
         <li><a href="careers.html">Careers</a></li>
@@ -60,7 +60,7 @@
     <ul>
       <li><a href="#about">About Us</a></li>
       <li><a href="#solutions">Solutions</a></li>
-      <li><a href="#projects">Projects</a></li>
+      <li><a href="#projects">Portfolio</a></li>
       <li><a href="#testimonials">Testimonials</a></li>
       <li><a href="#contact">Contact</a></li>
       <li><a href="careers.html">Careers</a></li>
@@ -156,10 +156,10 @@
     </div>
   </section>
 
-  <!-- Projects Section -->
+  <!-- Portfolio Section -->
   <section id="projects" class="projects">
-    <h2>Our Recent Projects</h2>
-    <div class="carousel-container">
+    <h2>Our Portfolio</h2>
+    <div class="carousel-container" data-images-to-show="2">
       <button class="carousel-arrow left-arrow">&#10094;</button>
       <div class="carousel">
         <div class="carousel-images">
@@ -241,42 +241,6 @@
     <p>Developed by <a href="https://saasproductized.com" target="_blank" style="font-weight: bold;">SaaS Productized Co.</a></p>
   </div>
 
-    <!-- Inline JavaScript (carousel only) -->
-    <script>
-    document.addEventListener("DOMContentLoaded", function () {
-      const carousel = document.querySelector('.carousel-images');
-      const carouselImages = document.querySelectorAll('.carousel-img');
-      const leftArrow = document.querySelector('.left-arrow');
-      const rightArrow = document.querySelector('.right-arrow');
 
-      let currentIndex = 0;
-      const imagesToShow = 2; // Show two images at a time now
-      let imageWidth = carouselImages[0].clientWidth;
-
-      function updateCarousel() {
-        const newTransformValue = -currentIndex * imageWidth;
-        carousel.style.transform = `translateX(${newTransformValue}px)`;
-      }
-
-      rightArrow.addEventListener('click', () => {
-        if (currentIndex < carouselImages.length - imagesToShow) {
-          currentIndex++;
-          updateCarousel();
-        }
-      });
-
-      leftArrow.addEventListener('click', () => {
-        if (currentIndex > 0) {
-          currentIndex--;
-          updateCarousel();
-        }
-      });
-
-      window.addEventListener('resize', () => {
-        imageWidth = carouselImages[0].clientWidth;
-        updateCarousel();
-      });
-    });
-  </script>
 </body>
 </html>

--- a/landscape_construction.html
+++ b/landscape_construction.html
@@ -27,7 +27,7 @@
       <ul class="desktop-menu">
         <li><a href="index.html#about">About Us</a></li>
         <li><a href="index.html#solutions">Solutions</a></li>
-        <li><a href="index.html#projects">Projects</a></li>
+        <li><a href="index.html#projects">Portfolio</a></li>
         <li><a href="index.html#testimonials">Testimonials</a></li>
         <li><a href="index.html#contact">Contact</a></li>
         <li><a href="careers.html">Careers</a></li>
@@ -44,7 +44,7 @@
     <ul>
       <li><a href="index.html#about">About Us</a></li>
       <li><a href="index.html#solutions">Solutions</a></li>
-      <li><a href="index.html#projects">Projects</a></li>
+      <li><a href="index.html#projects">Portfolio</a></li>
       <li><a href="index.html#testimonials">Testimonials</a></li>
       <li><a href="index.html#contact">Contact</a></li>
       <li><a href="careers.html">Careers</a></li>
@@ -119,44 +119,7 @@
     <p>Developed by <a href="https://saasproductized.com" target="_blank" style="font-weight: bold;">SaaS Productized Co.</a></p>
   </div>
 
-  <!-- Script -->
-  <script>
-    document.addEventListener("DOMContentLoaded", function () {
-      const carousel = document.querySelector('.carousel-images');
-      const slides = document.querySelectorAll('.carousel-img');
-      const leftArrow = document.querySelector('.left-arrow');
-      const rightArrow = document.querySelector('.right-arrow');
-
-      let currentIndex = 0;
-      const imagesToShow = 1;
-      let imageWidth = slides[0].clientWidth;
-
-      function updateCarousel() {
-        const newTransformValue = -currentIndex * imageWidth;
-        carousel.style.transform = \`translateX(\${newTransformValue}px)\`;
-      }
-
-      rightArrow.addEventListener('click', () => {
-        if (currentIndex < slides.length - imagesToShow) {
-          currentIndex++;
-          updateCarousel();
-        }
-      });
-
-      leftArrow.addEventListener('click', () => {
-        if (currentIndex > 0) {
-          currentIndex--;
-          updateCarousel();
-        }
-      });
-
-      window.addEventListener('resize', () => {
-        imageWidth = slides[0].clientWidth;
-        updateCarousel();
-      });
-    });
-  </script>
-</body>
+  </body>
 </html>
 
 

--- a/script.js
+++ b/script.js
@@ -76,6 +76,7 @@ function init() {
   initSectionObserver();
   highlightCurrentPage();
   openMenuIfFlag();
+  initCarousels();
 }
 
 if (document.readyState === 'loading') {
@@ -115,4 +116,45 @@ function openMenuIfFlag() {
     localStorage.removeItem('keepMobileMenuOpen');
     localStorage.removeItem('activeLink');
   }
+}
+
+function initCarousels() {
+  document.querySelectorAll('.carousel-container').forEach(container => {
+    const carousel = container.querySelector('.carousel-images');
+    const slides = container.querySelectorAll('.carousel-img');
+    const leftArrow = container.querySelector('.left-arrow');
+    const rightArrow = container.querySelector('.right-arrow');
+
+    if (!carousel || slides.length === 0) return;
+
+    const imagesToShow = parseInt(container.getAttribute('data-images-to-show')) || 1;
+    let currentIndex = 0;
+    let imageWidth = slides[0].clientWidth;
+
+    function updateCarousel() {
+      const newTransformValue = -currentIndex * imageWidth;
+      carousel.style.transform = `translateX(${newTransformValue}px)`;
+    }
+
+    rightArrow.addEventListener('click', () => {
+      currentIndex++;
+      if (currentIndex > slides.length - imagesToShow) {
+        currentIndex = 0;
+      }
+      updateCarousel();
+    });
+
+    leftArrow.addEventListener('click', () => {
+      currentIndex--;
+      if (currentIndex < 0) {
+        currentIndex = Math.max(slides.length - imagesToShow, 0);
+      }
+      updateCarousel();
+    });
+
+    window.addEventListener('resize', () => {
+      imageWidth = slides[0].clientWidth;
+      updateCarousel();
+    });
+  });
 }

--- a/snow.html
+++ b/snow.html
@@ -27,7 +27,7 @@
       <ul class="desktop-menu">
         <li><a href="index.html#about">About Us</a></li>
         <li><a href="index.html#solutions">Solutions</a></li>
-        <li><a href="index.html#projects">Projects</a></li>
+        <li><a href="index.html#projects">Portfolio</a></li>
         <li><a href="index.html#testimonials">Testimonials</a></li>
         <li><a href="index.html#contact">Contact</a></li>
         <li><a href="careers.html">Careers</a></li>
@@ -44,7 +44,7 @@
     <ul>
       <li><a href="index.html#about">About Us</a></li>
       <li><a href="index.html#solutions">Solutions</a></li>
-      <li><a href="index.html#projects">Projects</a></li>
+      <li><a href="index.html#projects">Portfolio</a></li>
       <li><a href="index.html#testimonials">Testimonials</a></li>
       <li><a href="index.html#contact">Contact</a></li>
       <li><a href="careers.html">Careers</a></li>
@@ -121,44 +121,7 @@
     <p>Developed by <a href="https://saasproductized.com" target="_blank" style="font-weight: bold;">SaaS Productized Co.</a></p>
   </div>
 
-  <!-- Script -->
-  <script>
-    document.addEventListener("DOMContentLoaded", function () {
-      const carousel = document.querySelector('.carousel-images');
-      const slides = document.querySelectorAll('.carousel-img');
-      const leftArrow = document.querySelector('.left-arrow');
-      const rightArrow = document.querySelector('.right-arrow');
-
-      let currentIndex = 0;
-      const imagesToShow = 1;
-      let imageWidth = slides[0].clientWidth;
-
-      function updateCarousel() {
-        const newTransformValue = -currentIndex * imageWidth;
-        carousel.style.transform = \`translateX(\${newTransformValue}px)\`;
-      }
-
-      rightArrow.addEventListener('click', () => {
-        if (currentIndex < slides.length - imagesToShow) {
-          currentIndex++;
-          updateCarousel();
-        }
-      });
-
-      leftArrow.addEventListener('click', () => {
-        if (currentIndex > 0) {
-          currentIndex--;
-          updateCarousel();
-        }
-      });
-
-      window.addEventListener('resize', () => {
-        imageWidth = slides[0].clientWidth;
-        updateCarousel();
-      });
-    });
-  </script>
-</body>
+  </body>
 </html>
 
 

--- a/stream_shoreline_restoration.html
+++ b/stream_shoreline_restoration.html
@@ -26,7 +26,7 @@
       <ul class="desktop-menu">
         <li><a href="index.html#about">About Us</a></li>
         <li><a href="index.html#solutions">Solutions</a></li>
-        <li><a href="index.html#projects">Projects</a></li>
+        <li><a href="index.html#projects">Portfolio</a></li>
         <li><a href="index.html#testimonials">Testimonials</a></li>
         <li><a href="index.html#contact">Contact</a></li>
         <li><a href="careers.html">Careers</a></li>
@@ -42,7 +42,7 @@
     <ul>
       <li><a href="index.html#about">About Us</a></li>
       <li><a href="index.html#solutions">Solutions</a></li>
-      <li><a href="index.html#projects">Projects</a></li>
+      <li><a href="index.html#projects">Portfolio</a></li>
       <li><a href="index.html#testimonials">Testimonials</a></li>
       <li><a href="index.html#contact">Contact</a></li>
       <li><a href="careers.html">Careers</a></li>
@@ -114,42 +114,7 @@
     <p>Developed by <a href="https://saasproductized.com" target="_blank" style="font-weight:bold;">SaaS Productized Co.</a></p>
   </div>
 
-  <script>
-    document.addEventListener("DOMContentLoaded", function () {
-      const carousel = document.querySelector('.carousel-images');
-      const slides = document.querySelectorAll('.carousel-img');
-      const leftArrow = document.querySelector('.left-arrow');
-      const rightArrow = document.querySelector('.right-arrow');
-      let currentIndex = 0;
-      const imagesToShow = 1;
-      let imageWidth = slides[0].clientWidth;
-
-      function updateCarousel() {
-        const newTransformValue = -currentIndex * imageWidth;
-        carousel.style.transform = \`translateX(\${newTransformValue}px)\`;
-      }
-
-      rightArrow.addEventListener('click', () => {
-        if (currentIndex < slides.length - imagesToShow) {
-          currentIndex++;
-          updateCarousel();
-        }
-      });
-
-      leftArrow.addEventListener('click', () => {
-        if (currentIndex > 0) {
-          currentIndex--;
-          updateCarousel();
-        }
-      });
-
-      window.addEventListener('resize', () => {
-        imageWidth = slides[0].clientWidth;
-        updateCarousel();
-      });
-    });
-  </script>
-</body>
+  </body>
 </html>
 
 

--- a/styles.css
+++ b/styles.css
@@ -33,6 +33,12 @@ body.needs-extra-padding {
   padding: 140px 20px 60px;
 }
 
+@media (max-width: 768px) {
+  body.needs-extra-padding {
+    padding-top: 100px;
+  }
+}
+
 /* Header */
 .header {
   background: lightgreen;
@@ -322,7 +328,7 @@ body.needs-extra-padding {
   .solution-item h3 { font-size: 1.3em; }
 }
 
-/* Projects Section */
+/* Portfolio Section */
 #projects {
   text-align: center;
   padding: 40px 20px;
@@ -390,6 +396,11 @@ body.needs-extra-padding {
 }
 .carousel-arrow.left-arrow { left: 0; }
 .carousel-arrow.right-arrow { right: 0; }
+
+@media (min-width: 769px) {
+  .carousel-arrow.left-arrow { left: 10px; }
+  .carousel-arrow.right-arrow { right: 10px; }
+}
 
 /* Testimonials Section */
 #testimonials {


### PR DESCRIPTION
## Summary
- Retitle navigation items and homepage section from "Projects" to "Portfolio".
- Reduce top padding on careers page for a tighter mobile layout and adjust carousel arrows on desktop.
- Implement shared carousel logic so sliders loop infinitely.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897956b10388321b2d33d1ff603237a