### PR TITLE
Add green accents and header shadow

### DIFF
--- a/script.js
+++ b/script.js
@@ -91,6 +91,7 @@ function init() {
   highlightCurrentPage();
   openMenuIfFlag();
   initCarousels();
+  initLogoGlow();
 }
 
 if (document.readyState === 'loading') {
@@ -178,5 +179,14 @@ function initCarousels() {
       imageWidth = slides[0].clientWidth;
       updateCarousel();
     });
+  });
+}
+
+function initLogoGlow() {
+  const logo = document.querySelector('.logo-container img');
+  if (!logo) return;
+  logo.addEventListener('click', function () {
+    logo.classList.add('glow');
+    setTimeout(() => logo.classList.remove('glow'), 500);
   });
 }

--- a/styles.css
+++ b/styles.css
@@ -52,8 +52,17 @@ body.needs-extra-padding {
   left: 0;
   width: 100%;
   z-index: 1000;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
 }
 .logo-container { text-align: center; }
+
+.logo-container img {
+  transition: box-shadow 0.3s ease;
+}
+
+.logo-container img.glow {
+  box-shadow: 0 0 10px #32CD32;
+}
 
 .main-nav {
   display: flex;
@@ -245,7 +254,7 @@ body.needs-extra-padding {
   font-family: 'Roboto Condensed', sans-serif;
   font-size: 2.5em;
   color: white;
-  text-shadow: 2px 2px 4px #000;
+  text-shadow: 2px 2px 4px #000, 0 0 5px #32CD32;
 }
 .about p {
   color: white;
@@ -278,6 +287,7 @@ body.needs-extra-padding {
   font-weight: bold;
   color: black;
   margin-bottom: 20px;
+  text-shadow: 0 0 5px #32CD32;
 }
 .solutions-list {
   display: flex;
@@ -293,7 +303,7 @@ body.needs-extra-padding {
   background: rgba(255,255,255,0.85);
   text-align: center;
   border-radius: 10px;
-  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1), 0 0 10px rgba(0,255,0,0.2);
   word-wrap: break-word;
   overflow-wrap: break-word;
   hyphens: auto;
@@ -339,6 +349,7 @@ body.needs-extra-padding {
   font-size: 2.5em;
   font-weight: bold;
   color: black;
+  text-shadow: 0 0 5px #32CD32;
 }
 .carousel-container {
   display: flex;
@@ -413,6 +424,7 @@ body.needs-extra-padding {
   font-size: 2.5em;
   font-weight: bold;
   color: black;
+  text-shadow: 0 0 5px #32CD32;
 }
 #testimonials p {
   margin-bottom: 20px;
@@ -511,6 +523,7 @@ body.needs-extra-padding {
   font-size: 2.5em;
   font-weight: bold;
   color: black;
+  text-shadow: 0 0 5px #32CD32;
 }
 @media (max-width: 768px) {
   .main-nav ul { display: none; }
@@ -560,6 +573,7 @@ body.needs-extra-padding {
   font-weight: bold;
   color: black;
   margin-bottom: 20px;
+  text-shadow: 0 0 5px #32CD32;
 }
 .service-detail p {
   font-family: 'Open Sans', sans-serif;


### PR DESCRIPTION
## Summary
- Add box shadow under fixed header and animate logo with a green glow on click
- Give all section titles a subtle green glow
- Add light green box shadow to service boxes for better separation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898dd53bdc08321a9ad6c0c3dc05f87