### PR TITLE
Tweak section styling and add subtle accents

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,7 +204,7 @@
 
   <!-- Service Area Section -->
   <section id="service-area" class="service-area">
-    <h2 style="font-family: 'Roboto Condensed', sans-serif; font-size: 2.5em; font-weight: bold;">Service Area</h2>
+    <h2>Service Area</h2>
     <div class="map-container">
       <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d118752.26740673995!2d-87.9440712!3d41.836944!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x880e2db5e8f1b4f3%3A0x803401903c6c23bf!2sChicago%2C%20IL!5e0!3m2!1sen!2sus!4v1677677015914!5m2!1sen!2sus" width="600" height="400" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -101,6 +101,7 @@ body.needs-extra-padding {
   left: 20px;
   top: 20px;
   z-index: 1500;
+  filter: drop-shadow(1px 1px 2px rgba(0,0,0,0.6));
 }
 .hamburger.active { color: limegreen; text-shadow: 0 0 10px limegreen; }
 
@@ -199,6 +200,8 @@ body.needs-extra-padding {
   color: white;
   font-weight: bold;
   text-shadow: 0 0 5px rgba(255,255,255,0.7), 2px 2px 4px #000;
+  -webkit-text-stroke: 1px red;
+  text-stroke: 1px red;
   font-family: 'Playfair Display', serif;
   font-style: italic;
   font-size: 2rem;
@@ -254,7 +257,7 @@ body.needs-extra-padding {
   font-family: 'Roboto Condensed', sans-serif;
   font-size: 2.5em;
   color: white;
-  text-shadow: 2px 2px 4px #000, 0 0 5px #32CD32;
+  text-shadow: 2px 2px 4px #000, 0 0 3px #32CD32;
 }
 .about p {
   color: white;
@@ -287,7 +290,7 @@ body.needs-extra-padding {
   font-weight: bold;
   color: black;
   margin-bottom: 20px;
-  text-shadow: 0 0 5px #32CD32;
+  text-shadow: 0 0 3px #32CD32;
 }
 .solutions-list {
   display: flex;
@@ -349,7 +352,7 @@ body.needs-extra-padding {
   font-size: 2.5em;
   font-weight: bold;
   color: black;
-  text-shadow: 0 0 5px #32CD32;
+  text-shadow: 0 0 3px #32CD32;
 }
 .carousel-container {
   display: flex;
@@ -424,7 +427,7 @@ body.needs-extra-padding {
   font-size: 2.5em;
   font-weight: bold;
   color: black;
-  text-shadow: 0 0 5px #32CD32;
+  text-shadow: 0 0 3px #32CD32;
 }
 #testimonials p {
   margin-bottom: 20px;
@@ -462,6 +465,14 @@ body.needs-extra-padding {
 }
 
 /* Service Area Map */
+.service-area h2 {
+  font-family: 'Roboto Condensed', sans-serif;
+  font-size: 2.5em;
+  font-weight: bold;
+  color: black;
+  text-shadow: 0 0 3px #32CD32;
+}
+
 .map-container {
   width: 100%;
   display: flex;
@@ -523,7 +534,7 @@ body.needs-extra-padding {
   font-size: 2.5em;
   font-weight: bold;
   color: black;
-  text-shadow: 0 0 5px #32CD32;
+  text-shadow: 0 0 3px #32CD32;
 }
 @media (max-width: 768px) {
   .main-nav ul { display: none; }
@@ -573,7 +584,7 @@ body.needs-extra-padding {
   font-weight: bold;
   color: black;
   margin-bottom: 20px;
-  text-shadow: 0 0 5px #32CD32;
+  text-shadow: 0 0 3px #32CD32;
 }
 .service-detail p {
   font-family: 'Open Sans', sans-serif;


### PR DESCRIPTION
## Summary
- Soften section heading glow and include the Service Area header in the effect
- Give the mobile hamburger icon a small drop shadow
- Outline the main banner quote with a thin red stroke

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6898e005b1608321987d8852dc2e6df7