### PR TITLE
Move reviews widget onto banner and display ratings data

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,10 +52,6 @@
       </div>
     </nav>
   </header>
-  <div id="customer-reviews" class="customer-reviews">
-    <div class="star-rating" aria-label="Customer review rating"></div>
-  </div>
-
   <!-- Mobile Menu (hidden by default; toggled via JS) -->
   <div class="mobile-menu">
     <!-- Close Button -->
@@ -88,6 +84,11 @@
     <p class="hero-motto">
       “Serving Chicagoland’s landscape professionals with excellence for over <span class="motto-years">30 years.”</span>
     </p>
+    <div id="customer-reviews" class="customer-reviews">
+      <span class="rating-number"></span>
+      <div class="star-rating" aria-label="Customer review rating"></div>
+      <span class="rating-count"></span>
+    </div>
     <a href="#contact" class="read-more-btn request-estimate-btn">Request Estimate</a>
   </section>
 

--- a/script.js
+++ b/script.js
@@ -193,17 +193,26 @@ function initLogoGlow() {
 }
 
 function initReviewStars() {
-  const container = document.querySelector('.customer-reviews .star-rating');
-  if (!container) return;
+  const wrapper = document.querySelector('.customer-reviews');
+  if (!wrapper) return;
+  const starContainer = wrapper.querySelector('.star-rating');
+  const ratingNumberEl = wrapper.querySelector('.rating-number');
+  const ratingCountEl = wrapper.querySelector('.rating-count');
   const endpoint = 'https://example.com/api/reviews';
   fetch(endpoint)
     .then(res => res.json())
     .then(data => {
       const rating = parseFloat(data.rating) || 0;
-      renderStars(container, rating);
+      const count = parseInt(data.count) || 0;
+      if (ratingNumberEl) ratingNumberEl.textContent = rating.toFixed(1);
+      if (ratingCountEl) ratingCountEl.textContent = `(${count} Ratings & Reviews)`;
+      renderStars(starContainer, rating);
     })
     .catch(() => {
-      renderStars(container, 4.5);
+      const fallback = 4.5;
+      if (ratingNumberEl) ratingNumberEl.textContent = fallback.toFixed(1);
+      if (ratingCountEl) ratingCountEl.textContent = '(0 Ratings & Reviews)';
+      renderStars(starContainer, fallback);
     });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -111,8 +111,22 @@ body.needs-extra-padding {
 
 /* Customer Reviews Star Rating */
 .customer-reviews {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
   text-align: center;
-  margin-top: 90px;
+  margin: 15px 0;
+  color: white;
+}
+
+.customer-reviews .rating-number,
+.customer-reviews .rating-count {
+  font-size: 1rem;
+}
+
+.customer-reviews .star-rating {
+  display: flex;
 }
 
 .customer-reviews .star-rating i {
@@ -251,8 +265,6 @@ body.needs-extra-padding {
   color: white;
   font-weight: bold;
   text-shadow: 0 0 5px rgba(255,255,255,0.7), 2px 2px 4px #000;
-  -webkit-text-stroke: 0.1px red;
-  text-stroke: 0.1px red;
   font-family: 'Playfair Display', serif;
   font-style: italic;
   font-size: 2rem;
@@ -274,8 +286,6 @@ body.needs-extra-padding {
 @media (min-width: 1024px) {
   .hero-motto {
     font-size: 2.5rem;
-    -webkit-text-stroke: 0.05px red;
-    text-stroke: 0.05px red;
   }
 }
 


### PR DESCRIPTION
## Summary
- Overlay reviews widget between hero quote and call-to-action on banner
- Remove red stroke from hero quote
- Populate review stars with live rating number and count

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898e7d16ba88321b66bd948d03c6564