### PR TITLE
Fix reviews fallback and update site metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Professional landscaping services including lawn care, hardscaping, garden design, and more.">
+  <meta name="description" content="Expert Chicago landscaping construction contractors offering lawn care, hardscaping, garden design, and more.">
   <meta name="keywords" content="landscaping, lawn care, garden design, hardscaping, outdoor services">
-  <title>ANA'S LANDSCAPING LLC - Trusted Landscaping Solutions</title>
+    <title>ANA'S LANDSCAPING LLC - Expert Chicago Landscaping Construction Contractors</title>
 
   <!-- Favicons -->
-  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
-  <link rel="manifest" href="site.webmanifest">
-  <link rel="icon" href="favicon.ico" type="image/x-icon">
-  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Fonts and Icons -->
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700&display=swap" rel="stylesheet">

--- a/script.js
+++ b/script.js
@@ -199,20 +199,27 @@ function initReviewStars() {
   const ratingNumberEl = wrapper.querySelector('.rating-number');
   const ratingCountEl = wrapper.querySelector('.rating-count');
   const endpoint = 'https://example.com/api/reviews';
+  const defaultRating = 5;
+  const defaultCount = 7;
   fetch(endpoint)
     .then(res => res.json())
     .then(data => {
-      const rating = parseFloat(data.rating) || 0;
-      const count = parseInt(data.count) || 0;
-      if (ratingNumberEl) ratingNumberEl.textContent = rating.toFixed(1);
-      if (ratingCountEl) ratingCountEl.textContent = `(${count} Ratings & Reviews)`;
-      renderStars(starContainer, rating);
+      const rating = parseFloat(data.rating);
+      const count = parseInt(data.count);
+      if (rating > 0 && count > 0) {
+        if (ratingNumberEl) ratingNumberEl.textContent = rating.toFixed(1);
+        if (ratingCountEl) ratingCountEl.textContent = `(${count} Ratings & Reviews)`;
+        renderStars(starContainer, rating);
+      } else {
+        if (ratingNumberEl) ratingNumberEl.textContent = defaultRating.toFixed(1);
+        if (ratingCountEl) ratingCountEl.textContent = `(${defaultCount} Ratings & Reviews)`;
+        renderStars(starContainer, defaultRating);
+      }
     })
     .catch(() => {
-      const fallback = 4.5;
-      if (ratingNumberEl) ratingNumberEl.textContent = fallback.toFixed(1);
-      if (ratingCountEl) ratingCountEl.textContent = '(0 Ratings & Reviews)';
-      renderStars(starContainer, fallback);
+      if (ratingNumberEl) ratingNumberEl.textContent = defaultRating.toFixed(1);
+      if (ratingCountEl) ratingCountEl.textContent = `(${defaultCount} Ratings & Reviews)`;
+      renderStars(starContainer, defaultRating);
     });
 }
 


### PR DESCRIPTION
## Summary
- Default reviews widget to 5 stars and 7 reviews when no data is available
- Refresh page metadata and connect favicon paths to root

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898ec6945788321afe1ea32500a9640