### PR TITLE
Refine About Us section with concise copy and team photos

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,9 +96,13 @@
   <section id="about" class="about">
     <h2>About Us</h2>
     <div class="about-us-content">
-      <p>At Ana's Landscaping LLC, we specialize in creating both traditional and ecological landscapes that enhance the environment functionally and aesthetically. With over 30 years of experience, our family-owned business provides top-tier landscaping services for residential and commercial properties across Chicagoland.</p>
-      <p>Our services include lawn care, garden transformations, landscape and hardscape installation, ecological restoration, and green infrastructure. Our team of certified professionals is skilled in delivering projects of all sizes with precision and quality materials.</p>
-      <p>We are committed to providing ecologically and economically driven solutions that exceed client expectations. At Ana's Landscaping LLC, we build lasting relationships with our clients, aiming for sustainable solutions that positively impact both the environment and communities we serve.</p>
+      <p>Ana's Landscaping LLC is a family-owned company with over 30 years of experience crafting traditional and ecological landscapes across Chicagoland.</p>
+      <p>Our certified team delivers lawn care, garden design, hardscapes, ecological restoration, and green infrastructure for residential and commercial clients. We focus on sustainable, cost-effective results that strengthen our communities and the environment.</p>
+      <div class="about-gallery">
+        <img src="careers6.jpg" alt="Team members working on site">
+        <img src="careers7.jpg" alt="Crew positions available">
+        <img src="careers8.jpg" alt="Join our landscaping team">
+      </div>
     </div>
     <!-- Read More button for About Us -->
     <a href="careers.html" class="read-more-btn careers-btn">Careers</a>

--- a/styles.css
+++ b/styles.css
@@ -340,6 +340,18 @@ body.needs-extra-padding {
   font-weight: 600;
 }
 
+.about .about-gallery {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.about .about-gallery img {
+  width: 30%;
+  border-radius: 5px;
+}
+
 /* Solutions Section */
 .solutions {
   background: url('2.jpeg') no-repeat center center/cover;


### PR DESCRIPTION
## Summary
- Streamline About Us copy for clarity and impact.
- Showcase team culture by adding three photos from the careers page.
- Style new image gallery for responsive layout.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a44802548832196ec86f4f0212eb8