### PR TITLE
Restore hero banner opacity

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -245,6 +245,7 @@ body.needs-extra-padding {
   font-size: 2.5em;
   text-shadow: 3px 3px 6px rgba(0,0,0,0.6);
   position: relative;
+  opacity: 0.8;
 }
 @media (max-width: 768px) {
   .main-banner { padding-top: 100px; }


### PR DESCRIPTION
## Summary
- Reapply 0.8 opacity to hero banner to restore darkened overlay on first image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689febc74bd0832193bd620741f3f2a9