### PR TITLE
Fix banner overlay to only affect background image

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -245,7 +245,6 @@ body.needs-extra-padding {
   font-size: 2.5em;
   text-shadow: 3px 3px 6px rgba(0,0,0,0.6);
   position: relative;
-  opacity: 0.8;
 }
 @media (max-width: 768px) {
   .main-banner { padding-top: 100px; }
@@ -258,7 +257,12 @@ body.needs-extra-padding {
   width: 100%;
   height: 100%;
   background-color: rgba(0,0,0,0.4);
-  z-index: -1;
+  z-index: 0;
+}
+
+.main-banner > * {
+  position: relative;
+  z-index: 1;
 }
 
 .hero-motto {


### PR DESCRIPTION
## Summary
- ensure main banner opacity overlay covers only background image, leaving text, ratings, and button fully visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fee8b21bc83219e632232a47d3a2c